### PR TITLE
update symbols server url

### DIFF
--- a/background_hang_reporter_job/main.py
+++ b/background_hang_reporter_job/main.py
@@ -685,7 +685,7 @@ default_config = {
     'end_date': datetime.today() - timedelta(days=1),
     'use_s3': True,
     'sample_size': 0.50,
-    'symbol_server_url': "https://s3-us-west-2.amazonaws.com/org.mozilla.crash-stats.symbols-public/v1/",
+    'symbol_server_url': "https://symbols.mozilla.org/",
     'hang_profile_in_filename': 'hang_profile_128_16000',
     'hang_profile_out_filename': None,
     'print_debug_info': False,


### PR DESCRIPTION
background_hang_reporter_job is accessing the public symbols AWS S3 bucket directly rather than going through the Mozilla Symbols Server and getting redirected. We're planning to migrate to GCP and after we migrate, there won't be any AWS S3 bucket.

This fixes background_hang_reporter_job so that it works with our current setup as well as the setup we'll have after the GCP migration.

Details: https://bugzilla.mozilla.org/show_bug.cgi?id=1831952